### PR TITLE
URL Encode Search / line breaks

### DIFF
--- a/LiveCode Multi-Search/maingroupid1032searchbuttonbehavior.livecodescript
+++ b/LiveCode Multi-Search/maingroupid1032searchbuttonbehavior.livecodescript
@@ -22,37 +22,52 @@ on mouseUp pMouseButton
    local tSearchLCLessons
    local tSearchGitHub
    local tSearchLCDict
+   local tSearchLCWiki
+   
+   put URLEncode(fld "Search") into tSearch
    
    --Gist
-   put "https://gist.github.com/search?q=" & fld "Search" & tExtension & "&ref=opensearch" into tSearchGist
+   put "https://gist.github.com/search?q=" & tSearch & tExtension & \
+         "&ref=opensearch" into tSearchGist
    set the url of widget "Browser GitHub Gist" to tSearchGist
    
    --LC Forum
-   put "http://forums.livecode.com/search.php?keywords=" & fld "Search" into tSearchLCForum
+   put "http://forums.livecode.com/search.php?keywords=" & tSearch \
+         into tSearchLCForum
    set the url of widget "Browser LC Forum" to tSearchLCForum
    
    --Nabble
-   put "http://runtime-revolution.278305.n4.nabble.com/template/NamlServlet.jtp?macro=search_page&node=278305&query=" & fld "Search" into tSearchNabbleForum
+   put "http://runtime-revolution.278305.n4.nabble.com/template/" & \
+         "NamlServlet.jtp?macro=search_page&node=278305&query=" & \
+         tSearch into tSearchNabbleForum
    set the url of widget "Browser Nabble Forum" to tSearchNabbleForum
    
    --StackOverflow
-   put "https://stackoverflow.com/search?q=%5Blivecode%5D+" & fld "Search" into tSearchStackOverflow
+   put "https://stackoverflow.com/search?q=%5Blivecode%5D+" & tSearch \
+         into tSearchStackOverflow
    set the url of widget "Browser StackOverflow" to tSearchStackOverflow
    
    --LC Lessons
-   put "http://lessons.livecode.com/searches?&text=" & fld "Search" & "&commit=Search" into tSearchLCLessons
+   put "http://lessons.livecode.com/searches?&text=" & tSearch & \
+         "&commit=Search" into tSearchLCLessons
    set the url of widget "Browser LC Lessons" to tSearchLCLessons
    
    --GitHub
-   put "https://github.com/search?q=livecode " & fld "Search" into tSearchGitHub
+   put "https://github.com/search?q=livecode+" & tSearch into tSearchGitHub
    set the url of widget "Browser GitHub" to tSearchGitHub
    
    --LC Dictionary
-   put "http://2108.co.uk/LCDict/api.html?search=" & fld "Search" into tSearchLCDict
-   set the url of widget "Browser LC Dictionary" to tSearchLCDict
-   
+   do "displayEntryListGrep(" & quote & fld "Search" & quote & ")" \
+         in widget "Browser LC Dictionary"
+   -- don't need this code if using the above method.  The search field
+   -- does not get populated, but the search is executed immediately
+   -- requires the preload in the preOpenStack/emptyURLs handler
+   --put "http://2108.co.uk/LCDict/api.html?search=" & fld "Search" into tSearchLCDict
+   --set the url of widget "Browser LC Dictionary" to tSearchLCDict
+
    --LC Wiki
-   put "http://livecode.wikia.com/wiki/Special:Search?query=" & fld "Search" into tSearchLCWiki
+   put "http://livecode.wikia.com/wiki/Special:Search?query=" & tSearch \
+         into tSearchLCWiki
    set the url of widget "Browser LC Wiki" to tSearchLCWiki
    
    

--- a/LiveCode Multi-Search/stackbehavior.livecodescript
+++ b/LiveCode Multi-Search/stackbehavior.livecodescript
@@ -46,7 +46,7 @@ on emptyUrls
    repeat with tControl = 1 to tControlCount
       
       if the name of control tControl of card "Main" of stack "LiveCode Multi-Search" contains "Browser" then
-         put the name of control tControl of card "Main" of stack "LiveCode Multi-Search" & comma after tBrowserWidgetNames
+         put the short name of control tControl of card "Main" of stack "LiveCode Multi-Search" & comma after tBrowserWidgetNames
       end if
       
    end repeat
@@ -55,13 +55,15 @@ on emptyUrls
    delete char -1 of tBrowserWidgetNames
    
    
-   --hide Browser widgets
-   repeat with tBrowserSelected = 1 to the number of items of tBrowserWidgetNames
+   --clear Browser widget URLs
+   repeat for each item tBrowserSelected in tBrowserWidgetNames
       
-      set the url of control item tBrowserSelected of tBrowserWidgetNames of card "Main" of stack "LiveCode Multi-Search" to empty
+      set the url of control tBrowserSelected of card "Main" of stack "LiveCode Multi-Search" to empty
       
    end repeat
    
+   -- preload dictionary to have the database file downloaded and available
+   set the url of widget "Browser LC Dictionary" to "http://2108.co.uk/LCDict/api.html"
    
 end emptyUrls
 


### PR DESCRIPTION
Wrapped lines in the search button to ~80 char
URLEncode the search string
Changed the trailing " " to "+" in the GitHub search
Added code to directly perform the LC Dictionary search (will not require the URL method)
Added local for the Wiki search string

Stack behavior doesn't seem to execute when running from the GitHub repo.
The `emptyUrls` handler isn't firing.  Made adjustments to the code that
are needed for the other changes.